### PR TITLE
fix(#110): 移除指标页工具栏的时间范围标签 

### DIFF
--- a/src/views/metrics.rs
+++ b/src/views/metrics.rs
@@ -984,13 +984,6 @@ impl Render for ZedisMetrics {
                 .text(i18n_common(cx, "loading"))
                 .into_any_element();
         }
-        let time_range = if let Some(first) = self.metrics_chart_data.dates.first()
-            && let Some(last) = self.metrics_chart_data.dates.last()
-        {
-            format!("{first} - {last}")
-        } else {
-            "".to_string()
-        };
         let has_chart_data = !self.metrics_chart_data.dates.is_empty();
         div()
             .size_full()
@@ -1031,22 +1024,16 @@ impl Render for ZedisMetrics {
                                     )
                                     .child(Label::new(self.title.clone())),
                             )
-                            .child(
-                                h_flex()
-                                    .items_center()
-                                    .gap_2()
-                                    .child(h_flex().gap_1().children(MetricsRange::ALL.map(|range| {
-                                        let selected = self.range == range;
-                                        let button = Button::new(range.button_id())
-                                            .xsmall()
-                                            .label(i18n_metrics(cx, range.label_key()));
-                                        let button = if selected { button.primary() } else { button.ghost() };
-                                        button.on_click(
-                                            cx.listener(move |this, _, _window, cx| this.set_range(range, cx)),
-                                        )
-                                    })))
-                                    .child(Label::new(time_range)),
-                            ),
+                            .child(h_flex().items_center().gap_2().child(h_flex().gap_1().children(
+                                MetricsRange::ALL.map(|range| {
+                                    let selected = self.range == range;
+                                    let button = Button::new(range.button_id())
+                                        .xsmall()
+                                        .label(i18n_metrics(cx, range.label_key()));
+                                    let button = if selected { button.primary() } else { button.ghost() };
+                                    button.on_click(cx.listener(move |this, _, _window, cx| this.set_range(range, cx)))
+                                }),
+                            ))),
                     )
                     .child(self.render_stat_cards(columns, cx))
                     .when(has_chart_data, |this| {


### PR DESCRIPTION
### 变动描述
移除指标页工具栏的时间范围标签，去掉 header 右侧基于图表轴首尾时间拼接的展示，保留 Live/1h/24h/7d 范围选择器。
### 变动类型
- [x] 🐛 Bug 修复 (修复现有问题的非破坏性修改)
- [ ] ✨ 新特性 (我已提前提交 Issue 并经过了讨论和评估)
- [ ] 🛠️ 代码重构 / 性能优化 (底层架构调整，不影响外部行为)
- [ ] 📝 文档完善 / 多语言 (i18n) 更新

### 开发者自查表
- [x] 我已运行 `cargo fmt` 格式化代码。
- [x] 我已运行 `cargo clippy` 并修复了所有警告。
- [x] 我的代码可以在本地成功编译并运行。
- [x] ⚖️ **我已阅读并同意 [Zedis 贡献者许可协议](CLA.md)，确认我的贡献为原创，并授权在项目的开源协议下使用。**
- [x] (可选) 我已在以下平台进行过测试： [x] macOS / [ ] Windows / [ ] Linux。
